### PR TITLE
docs: align crawl TVF named params with community LOAD crawler

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,85 +1,106 @@
 # DuckDB Crawler Extension - Examples
 
+Community `LOAD crawler` registers `crawl()` / `crawl_url()` / `sitemap()`. Named param `timeout` is **seconds**. Session default `crawler_timeout_ms` is **milliseconds**. `CRAWL (SELECT …) INTO` is a parser error on stock community.
+
 ## Basic Usage
 
 ### Crawl a website
 
 ```sql
--- Load extension (if not auto-loaded)
-LOAD 'build/release/extension/crawler/crawler.duckdb_extension';
+INSTALL crawler FROM community;
+LOAD crawler;
 
--- Crawl a site into a table (LIMIT is pushed down to crawler)
-CRAWL (SELECT 'https://example.com/') INTO pages
-WITH (user_agent 'MyBot/1.0') LIMIT 100;
+CREATE TABLE pages AS
+SELECT * FROM crawl(
+    'https://example.com/',
+    user_agent := 'MyBot/1.0',
+    timeout := 30,
+    max_results := 100
+);
 
--- View results
-SELECT url, http_status, content_type FROM pages LIMIT 10;
+SELECT url, status, content_type FROM pages;
 ```
 
 ### Crawl localhost for testing
 
 ```sql
-CRAWL (SELECT 'http://localhost:8080/test.html') INTO test_pages
-WITH (user_agent 'TestBot/1.0') LIMIT 1;
+CREATE TABLE test_pages AS
+SELECT * FROM crawl(
+    'http://localhost:8080/test.html',
+    user_agent := 'TestBot/1.0',
+    timeout := 30,
+    max_results := 1
+);
 ```
 
 ### LIMIT pushdown
 
-The `LIMIT N` clause is pushed down to the crawler, stopping after N pages:
+`max_results` (and `LIMIT` on `crawl()`) stop the fetch after N pages:
 
 ```sql
--- These are equivalent:
-CRAWL (SELECT 'https://example.com/') INTO pages WITH (user_agent 'Bot/1.0') LIMIT 50;
-CRAWL (SELECT 'https://example.com/') INTO pages WITH (user_agent 'Bot/1.0', max_crawl_pages 50);
+SELECT * FROM crawl('https://example.com/', user_agent := 'Bot/1.0', timeout := 30, max_results := 50);
+SELECT * FROM crawl('https://example.com/', user_agent := 'Bot/1.0', timeout := 30) LIMIT 50;
 ```
 
 ## Result Table Schema
 
-The crawler creates a table with these columns:
+`crawl()` / `crawl_url()` columns:
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `url` | VARCHAR | Original URL (primary key) |
-| `surt_key` | VARCHAR | SURT-formatted URL for sorting |
-| `http_status` | INTEGER | HTTP status code (200, 404, etc.) |
-| `body` | VARCHAR | Page HTML content |
-| `content_type` | VARCHAR | MIME type (text/html, etc.) |
-| `elapsed_ms` | BIGINT | Request time in milliseconds |
-| `crawled_at` | TIMESTAMP | When page was fetched |
-| `error` | VARCHAR | Error message if failed |
-| `etag` | VARCHAR | HTTP ETag header |
-| `last_modified` | VARCHAR | HTTP Last-Modified header |
-| `content_hash` | VARCHAR | MD5 hash of body |
-| `error_type` | VARCHAR | Error classification |
+| `url` | VARCHAR | Fetched URL |
+| `status` | INTEGER | HTTP status code |
+| `content_type` | VARCHAR | MIME type |
+| `html` | STRUCT | `document`, `js`, `meta`, `opengraph`, `schema`, `readability`, `hydration` |
 | `final_url` | VARCHAR | URL after redirects |
-| `redirect_count` | INTEGER | Number of redirects |
-| `jsonld` | VARCHAR | JSON-LD structured data |
-| `opengraph` | VARCHAR | OpenGraph meta tags |
-| `meta` | VARCHAR | HTML meta tags |
-| `hydration` | VARCHAR | React/Next.js hydration data |
-| `js` | VARCHAR | JavaScript variables |
+| `error` | VARCHAR | Error message if failed |
+| `extract` | VARCHAR | Result of `extract` specs |
+| `response_time_ms` | BIGINT | Request duration |
+| `depth` | INTEGER | Depth from seed |
 
-## WITH Clause Options
+## Named parameters
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `user_agent` | string | **required** | Bot user agent string |
-| `max_crawl_pages` | int | 1000 | Max pages to crawl |
-| `max_crawl_depth` | int | 10 | Max link depth from start |
-| `default_crawl_delay` | float | 1.0 | Seconds between requests |
-| `min_crawl_delay` | float | 0.5 | Minimum delay (adaptive) |
-| `max_crawl_delay` | float | 30.0 | Maximum delay (adaptive) |
-| `timeout_seconds` | int | 30 | HTTP request timeout |
-| `respect_robots_txt` | bool | true | Obey robots.txt rules |
-| `follow_links` | bool | true | Spider discovered links |
-| `allow_subdomains` | bool | false | Crawl subdomains |
-| `max_parallel_per_domain` | int | 4 | Concurrent requests/domain |
-| `max_total_connections` | int | 16 | Total concurrent requests |
-| `max_response_bytes` | int | 10MB | Max response size |
-| `compress` | bool | true | Accept gzip responses |
-| `accept_content_types` | string | "" | Filter by content type |
-| `reject_content_types` | string | "" | Reject content types |
-| `threads` | int | auto | Worker thread count |
+`timeout` is **seconds** on every TVF. `SET crawler_timeout_ms` is **milliseconds**.
+
+### crawl()
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `timeout` | INTEGER | HTTP timeout **in seconds** |
+| `max_results` | BIGINT | Cap on pages returned |
+| `max_depth` | INTEGER | Max follow depth |
+| `workers` | INTEGER | Concurrent requests |
+| `delay` | INTEGER | Per-domain delay (milliseconds in the binder) |
+| `respect_robots` | BOOLEAN | Honor robots.txt |
+| `cache` | BOOLEAN | HTTP response cache |
+| `cache_ttl` | INTEGER | Cache TTL (hours) |
+| `user_agent` | VARCHAR | User-Agent header |
+| `extract` | LIST(VARCHAR) | Extraction specs |
+| `follow` | VARCHAR | CSS selector for links to follow |
+| `batch_size` | INTEGER | URLs per fetch batch |
+| `state_table` | VARCHAR | Persistent crawl-state table |
+
+### crawl_url()
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `timeout` | INTEGER | HTTP timeout **in seconds** |
+| `max_results` | BIGINT | Cap on results |
+| `cache` | BOOLEAN | HTTP response cache |
+| `cache_ttl` | INTEGER | Cache TTL (hours) |
+| `user_agent` | VARCHAR | User-Agent header |
+| `extract` | LIST(VARCHAR) | Extraction specs |
+
+### sitemap()
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `timeout` | INTEGER | HTTP timeout **in seconds** |
+| `recursive` | BOOLEAN | Follow sitemap indexes |
+| `max_depth` | INTEGER | Max index recursion |
+| `discover` | BOOLEAN | Discover sitemap from robots.txt |
+| `filter` | VARCHAR | URL filter |
+| `user_agent` | VARCHAR | User-Agent header |
 
 ## Extracting Structured Data
 
@@ -89,12 +110,10 @@ The crawler creates a table with these columns:
 -- Get Product schema from e-commerce pages
 SELECT
     url,
-    jsonld::JSON->'@type' as schema_type,
-    jsonld::JSON->'name' as product_name,
-    jsonld::JSON->'offers'->'price' as price
+    html.schema['Product']->>'name' as product_name,
+    html.schema['Product']->'offers'->>'price' as price
 FROM pages
-WHERE jsonld IS NOT NULL
-  AND jsonld != '';
+WHERE html.schema['Product'] IS NOT NULL;
 ```
 
 ### OpenGraph Meta Tags
@@ -103,25 +122,25 @@ WHERE jsonld IS NOT NULL
 -- Extract social sharing metadata
 SELECT
     url,
-    opengraph::JSON->>'og:title' as title,
-    opengraph::JSON->>'og:description' as description,
-    opengraph::JSON->>'og:image' as image
+    html.opengraph->>'og:title' as title,
+    html.opengraph->>'og:description' as description,
+    html.opengraph->>'og:image' as image
 FROM pages
-WHERE opengraph IS NOT NULL;
+WHERE html.opengraph IS NOT NULL;
 ```
 
 ### JavaScript Variables
 
-The `js` column extracts top-level JS variable assignments:
+`html.js` extracts top-level JS variable assignments:
 
 ```sql
 -- Extract JS variables from pages
 SELECT
     url,
-    js::JSON->>'__INITIAL_STATE__' as initial_state,
-    js::JSON->>'productData' as product_data
+    html.js->>'__INITIAL_STATE__' as initial_state,
+    html.js->>'productData' as product_data
 FROM pages
-WHERE js IS NOT NULL AND js != '';
+WHERE html.js IS NOT NULL;
 ```
 
 Supported patterns:
@@ -135,9 +154,9 @@ Supported patterns:
 -- Extract Next.js page props
 SELECT
     url,
-    hydration::JSON->'__NEXT_DATA__'->'props' as page_props
+    html.hydration['__NEXT_DATA__']->'props' as page_props
 FROM pages
-WHERE hydration IS NOT NULL;
+WHERE html.hydration['__NEXT_DATA__'] IS NOT NULL;
 ```
 
 ## Working with JSON Arrays
@@ -145,7 +164,7 @@ WHERE hydration IS NOT NULL;
 ### Unnest JSON arrays
 
 ```sql
--- Extract items from a JSON array in js column
+-- Extract items from a JSON array in html.js
 SELECT
     p.url,
     item->>'title' as title,
@@ -153,24 +172,24 @@ SELECT
 FROM pages p,
 LATERAL unnest(
     CASE
-        WHEN js::JSON->'products' IS NOT NULL
-        THEN from_json(js::JSON->>'products', '["JSON"]')
+        WHEN html.js->'products' IS NOT NULL
+        THEN from_json(html.js->>'products', '["JSON"]')
         ELSE []
     END
 ) as t(item)
-WHERE js IS NOT NULL;
+WHERE html.js IS NOT NULL;
 ```
 
 ### Parse JSON array directly
 
 ```sql
--- If js contains an array like: {"items": [{"a":1},{"a":2}]}
+-- If html.js contains an array like: {"items": [{"a":1},{"a":2}]}
 WITH parsed AS (
     SELECT
         url,
-        json_extract(js::JSON, '$.items') as items_json
+        json_extract(html.js, '$.items') as items_json
     FROM pages
-    WHERE js IS NOT NULL
+    WHERE html.js IS NOT NULL
 )
 SELECT
     url,
@@ -184,10 +203,10 @@ WHERE items_json IS NOT NULL;
 ### Find pages with errors
 
 ```sql
-SELECT url, http_status, error, error_type
+SELECT url, status, error
 FROM pages
-WHERE http_status >= 400 OR error IS NOT NULL
-ORDER BY http_status DESC;
+WHERE status >= 400 OR error IS NOT NULL
+ORDER BY status DESC;
 ```
 
 ### Analyze content types
@@ -202,10 +221,10 @@ ORDER BY count DESC;
 ### Find slow pages
 
 ```sql
-SELECT url, elapsed_ms
+SELECT url, response_time_ms
 FROM pages
-WHERE elapsed_ms > 5000
-ORDER BY elapsed_ms DESC;
+WHERE response_time_ms > 5000
+ORDER BY response_time_ms DESC;
 ```
 
 ## Incremental Crawling
@@ -213,18 +232,27 @@ ORDER BY elapsed_ms DESC;
 ### Only crawl new/changed pages
 
 ```sql
--- Use update_stale to re-crawl pages with changed ETags
-CRAWL (SELECT 'https://example.com/') INTO pages
-WITH (user_agent 'MyBot/1.0', update_stale true);
+-- Re-crawl with cache disabled (or a short cache_ttl)
+INSERT INTO pages
+SELECT * FROM crawl(
+    'https://example.com/',
+    user_agent := 'MyBot/1.0',
+    timeout := 30,
+    cache := false
+);
 ```
 
 ### Resume interrupted crawl
 
 ```sql
--- The crawler automatically skips already-fetched URLs
--- Just run the same CRAWL command again
-CRAWL (SELECT 'https://example.com/') INTO pages
-WITH (user_agent 'MyBot/1.0', max_crawl_pages 10000);
+-- Persist progress in state_table; re-run with the same name
+SELECT * FROM crawl(
+    'https://example.com/',
+    user_agent := 'MyBot/1.0',
+    timeout := 30,
+    max_results := 10000,
+    state_table := 'crawl_state'
+);
 ```
 
 ## Multiple Sites
@@ -232,27 +260,22 @@ WITH (user_agent 'MyBot/1.0', max_crawl_pages 10000);
 ### Crawl multiple domains
 
 ```sql
-CRAWL (
-    SELECT column0 FROM (
-        VALUES
-            ('https://site1.com/'),
-            ('https://site2.com/'),
-            ('https://site3.com/')
-    )
-) INTO multi_site_pages
-WITH (user_agent 'MyBot/1.0', max_crawl_pages 100);
+CREATE TABLE multi_site_pages AS
+SELECT * FROM crawl(
+    ['https://site1.com/', 'https://site2.com/', 'https://site3.com/'],
+    user_agent := 'MyBot/1.0',
+    timeout := 30,
+    max_results := 100
+);
 ```
 
 ### Crawl from a table of URLs
 
 ```sql
--- First create a table with URLs
-CREATE TABLE urls_to_crawl (url VARCHAR);
-INSERT INTO urls_to_crawl VALUES
-    ('https://example1.com/page1'),
-    ('https://example2.com/page2');
+CREATE TABLE urls_to_crawl AS
+SELECT unnest(['https://example1.com/page1', 'https://example2.com/page2']) AS url;
 
--- Then crawl them
-CRAWL (SELECT url FROM urls_to_crawl) INTO crawled_pages
-WITH (user_agent 'MyBot/1.0');
+CREATE TABLE crawled_pages AS
+SELECT c.*
+FROM urls_to_crawl u, LATERAL crawl_url(u.url, timeout := 30, user_agent := 'MyBot/1.0') c;
 ```

--- a/README.md
+++ b/README.md
@@ -9,18 +9,17 @@ A high-performance web crawler extension for DuckDB that fetches web pages, extr
 INSTALL crawler FROM community;
 LOAD crawler;
 
--- Simple crawl
-CRAWL (SELECT 'https://example.com/')
-INTO pages
-WITH (max_crawl_pages 10);
-
--- View results
-SELECT url, status_code, length(body) as size FROM pages;
+-- One URL. Named param `timeout` is seconds (default 30).
+-- Distinct from SET crawler_timeout_ms (milliseconds).
+SELECT url, status, length(html.document) AS size
+FROM crawl('https://example.com/', timeout := 30);
 ```
+
+Stock community `LOAD crawler` registers table functions (`crawl`, `crawl_url`, `sitemap`, …). It does **not** register a `CRAWL` statement — `CRAWL (SELECT …) INTO …` is a parser error. This source tree’s parser (`src/crawl_parser.cpp`) is **MERGE-only** (`CRAWLING MERGE INTO`), and that registration is currently disabled (`parser_extensions` private in DuckDB 1.2+).
 
 ## Features
 
-- **Native SQL syntax** - `CRAWL` statement integrates seamlessly with DuckDB
+- **SQL table functions** - `crawl()`, `crawl_url()`, `sitemap()` with named parameters
 - **HTTP/1.1, HTTP/2** support via reqwest (Rust)
 - **Parallel crawling** with configurable thread pools
 - **robots.txt compliance** with crawl delay respect
@@ -40,14 +39,8 @@ SELECT url, status_code, length(body) as size FROM pages;
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                         CRAWL Statement                         │
-│         CRAWL (SELECT urls) INTO table WHERE ... WITH           │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    DuckDB Parser Extension                      │
-│      Parses CRAWL/INTO/WHERE/WITH into execution plan          │
+│              Table functions (community LOAD crawler)           │
+│     crawl(url | urls, timeout := …)  crawl_url()  sitemap()     │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -85,15 +78,15 @@ SELECT url, status_code, length(body) as size FROM pages;
 
 ### 1. URL Discovery
 
-The crawler starts with seed URLs from the subquery:
+The crawler starts with seed URLs from `crawl()` / `crawl_url()`:
 
 ```sql
-CRAWL (SELECT 'https://example.com/sitemap.xml')  -- Direct URLs
-CRAWL (SELECT url FROM my_urls)                    -- From table
-CRAWL (SELECT 'example.com')                       -- Auto-discover sitemap
+SELECT * FROM crawl('https://example.com/sitemap.xml', timeout := 30);
+SELECT * FROM crawl(['https://example.com/a', 'https://example.com/b']);
+SELECT * FROM sitemap('https://example.com/sitemap.xml', discover := true);
 ```
 
-If `follow_links` is enabled, it parses HTML for `<a href>` links and adds them to the queue, respecting `max_crawl_depth` and same-domain rules.
+If `follow` is a CSS selector, the crawler extracts matching links and queues them, respecting `max_depth`.
 
 ### 2. HTTP Fetching (reqwest)
 
@@ -164,7 +157,36 @@ duckdb -unsigned -c "LOAD 'build/release/extension/crawler/crawler.duckdb_extens
 
 ## Table Functions
 
-### crawl_url() - LATERAL Join Support
+These are what community `LOAD crawler` actually registers. Named parameter `timeout` is **seconds** on every TVF (binder multiplies by 1000). Session default is `SET crawler_timeout_ms` (**milliseconds**, default 30000).
+
+### crawl() — batch crawl
+
+```sql
+SELECT url, status, length(html.document) AS size
+FROM crawl('https://example.com/', timeout := 30);
+
+SELECT url, status
+FROM crawl(['https://example.com/a', 'https://example.com/b'],
+           timeout := 15, max_results := 10, respect_robots := true);
+```
+
+| Named param | Type | Description |
+|-------------|------|-------------|
+| `timeout` | INTEGER | HTTP request timeout **in seconds** (not ms) |
+| `max_results` | BIGINT | Cap on pages returned (LIMIT pushdown) |
+| `max_depth` | INTEGER | Max link-follow depth (`1` = seeds only) |
+| `workers` | INTEGER | Concurrent requests |
+| `delay` | INTEGER | Per-domain delay stored as milliseconds |
+| `respect_robots` | BOOLEAN | Honor robots.txt |
+| `cache` | BOOLEAN | HTTP response cache |
+| `cache_ttl` | INTEGER | Cache TTL in hours |
+| `user_agent` | VARCHAR | User-Agent header |
+| `extract` | LIST(VARCHAR) | Extraction specs |
+| `follow` | VARCHAR | CSS selector for links to follow |
+| `batch_size` | INTEGER | URLs per fetch batch |
+| `state_table` | VARCHAR | Persistent crawl-state table |
+
+### crawl_url() — LATERAL join support
 
 Use `crawl_url()` for row-by-row crawling with LATERAL joins:
 
@@ -173,33 +195,52 @@ Use `crawl_url()` for row-by-row crawling with LATERAL joins:
 SELECT
     seed.category,
     c.url,
-    c.status_code,
+    c.status,
     c.html.readability.title
 FROM seed_urls seed,
-LATERAL crawl_url(seed.url) AS c
-WHERE c.status_code = 200;
+LATERAL crawl_url(seed.url, timeout := 30) AS c
+WHERE c.status = 200;
 
 -- Chain with extraction
 SELECT
     c.final_url,
-    jq(c.body, 'h1').text as title,
+    jq(c.html.document, 'h1').text as title,
     c.html.schema['Product'] as product_data
 FROM urls_to_check u,
-LATERAL crawl_url(u.link) AS c;
+LATERAL crawl_url(u.link, timeout := 15) AS c;
 ```
 
-### sitemap() - Sitemap Parsing
+| Named param | Type | Description |
+|-------------|------|-------------|
+| `timeout` | INTEGER | HTTP request timeout **in seconds** |
+| `max_results` | BIGINT | Cap on results (also a 2nd positional arg in LATERAL) |
+| `cache` | BOOLEAN | HTTP response cache |
+| `cache_ttl` | INTEGER | Cache TTL in hours |
+| `user_agent` | VARCHAR | User-Agent header |
+| `extract` | LIST(VARCHAR) | Extraction specs |
+
+### sitemap() — sitemap parsing
 
 Parse XML sitemaps (supports gzip, recursive sitemap indexes):
 
 ```sql
 -- Get all URLs from sitemap
-SELECT * FROM sitemap('https://example.com/sitemap.xml');
+SELECT * FROM sitemap('https://example.com/sitemap.xml', timeout := 30);
 
 -- Recursive sitemap discovery
 SELECT url, lastmod, priority
-FROM sitemap('https://example.com/sitemap_index.xml', recursive := true);
+FROM sitemap('https://example.com/sitemap_index.xml',
+             recursive := true, timeout := 30);
 ```
+
+| Named param | Type | Description |
+|-------------|------|-------------|
+| `timeout` | INTEGER | HTTP request timeout **in seconds** |
+| `recursive` | BOOLEAN | Follow sitemap indexes |
+| `max_depth` | INTEGER | Max index recursion depth |
+| `discover` | BOOLEAN | Discover sitemap URL from robots.txt |
+| `filter` | VARCHAR | URL filter |
+| `user_agent` | VARCHAR | User-Agent header |
 
 ## Extraction Functions
 
@@ -240,7 +281,7 @@ SELECT htmlpath('<a href="/page">Link</a>', 'a@href');
 
 -- Extract from JSON-LD
 SELECT htmlpath(body, 'script[type="application/ld+json"]@text.Product.name')
-FROM pages WHERE status_code = 200;
+FROM pages WHERE status = 200;
 
 -- Extract multiple elements (returns JSON array)
 SELECT htmlpath(body, 'a.product@href[*]') FROM pages;
@@ -323,7 +364,9 @@ Supported extraction patterns:
 
 ## CRAWLING MERGE INTO
 
-Upsert crawl results with MERGE semantics. Supports conditional updates and handling of stale rows:
+Parser syntax in this source tree only (`CRAWLING MERGE INTO`, not `CRAWL INTO`). **Not registered** on stock community `LOAD crawler` (parser error at `CRAWLING`). On community, use DuckDB `MERGE` / `INSERT` over `crawl()`.
+
+When the parser is enabled, upsert crawl results with MERGE semantics:
 
 ```sql
 -- Basic upsert: update existing, insert new
@@ -345,7 +388,7 @@ USING (
     FROM crawl(['https://jobs.example.com/listings']) AS listing,
     LATERAL unnest(cast(htmlpath(listing.body, 'a.job@href[*]') as VARCHAR[])) AS t(job_url),
     LATERAL crawl_url(job_url) AS c
-    WHERE c.status_code = 200
+    WHERE c.status = 200
 ) AS src
 ON (src.url = jobs.url)
 WHEN MATCHED AND age(jobs.crawled_at) > INTERVAL '24 hours' THEN UPDATE BY NAME
@@ -394,7 +437,8 @@ SET crawler_default_delay = 1.0;
 -- Respect robots.txt (default: true)
 SET crawler_respect_robots = true;
 
--- Request timeout (milliseconds)
+-- Session default request timeout (milliseconds).
+-- Per-call override is crawl(..., timeout := seconds), not this name.
 SET crawler_timeout_ms = 30000;
 
 -- Maximum response size (bytes)
@@ -408,7 +452,7 @@ SET crawler_max_response_bytes = 10485760;  -- 10MB
 | `crawler_user_agent` | VARCHAR | required | HTTP User-Agent header |
 | `crawler_default_delay` | DOUBLE | 1.0 | Delay between requests (seconds) |
 | `crawler_respect_robots` | BOOLEAN | true | Honor robots.txt |
-| `crawler_timeout_ms` | INTEGER | 30000 | Request timeout |
+| `crawler_timeout_ms` | BIGINT | 30000 | Default request timeout **in milliseconds**. TVF named param `timeout` is **seconds**. |
 | `crawler_max_response_bytes` | INTEGER | 10485760 | Max response size |
 
 ## Proxy Support
@@ -448,81 +492,62 @@ See the `examples/` directory for complete working examples:
 | `examples/crawl_blog_posts.sql` | Blog article extraction with readability |
 | `examples/crawl_events.sql` | Event page crawling with Event schema |
 
-## CRAWL Statement Syntax
+## CRAWL statement (not on community)
+
+`CRAWL (SELECT …) INTO … WITH (…)` is **not** registered. On stock community:
 
 ```sql
-CRAWL (subquery)
-INTO table_name
-[WHERE url_filter]
-[WITH (options)]
-[LIMIT n]
+-- Parser Error: syntax error at or near "CRAWL"
+CRAWL (SELECT 'https://example.com/') INTO pages;
 ```
 
-### Components
-
-| Clause | Required | Description |
-|--------|----------|-------------|
-| `CRAWL (subquery)` | Yes | Source URLs - any SELECT returning URL strings |
-| `INTO table_name` | Yes | Target table (created if not exists) |
-| `WHERE condition` | No | URL filter applied before fetching |
-| `WITH (options)` | No | Crawler configuration |
-| `LIMIT n` | No | Maximum pages to crawl |
+`src/crawl_parser.cpp` handles **`CRAWLING MERGE INTO` only** (not `CRAWL INTO`). That parser is not loaded today (`parser_extensions` private in DuckDB 1.2+). Persist results with `CREATE TABLE AS` / `INSERT` / DuckDB `MERGE` over `crawl()` / `crawl_url()`.
 
 ## Output Schema
 
-The output table contains standard columns:
+`crawl()` / `crawl_url()` return:
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `url` | VARCHAR | Fetched URL |
-| `surt_key` | VARCHAR | SURT-normalized URL (Common Crawl format) |
-| `status_code` | INTEGER | HTTP status code |
-| `body` | VARCHAR | Response body |
+| `status` | INTEGER | HTTP status code |
 | `content_type` | VARCHAR | Content-Type header |
-| `crawled_at` | TIMESTAMP | Fetch timestamp |
-| `elapsed_ms` | BIGINT | Request duration |
-| `error` | VARCHAR | Error message if failed |
-| `error_type` | VARCHAR | Classified error type |
+| `html` | STRUCT | `document`, `js`, `meta`, `opengraph`, `schema`, `readability`, `hydration` |
 | `final_url` | VARCHAR | URL after redirects |
-| `redirect_count` | INTEGER | Number of redirects |
-| `etag` | VARCHAR | ETag header |
-| `last_modified` | VARCHAR | Last-Modified header |
-| `content_hash` | VARCHAR | SHA-256 of body |
-| `jsonld` | JSON | Full JSON-LD data |
-| `opengraph` | JSON | Full OpenGraph data |
-| `meta` | JSON | Full meta tags |
-| `js` | JSON | Full JS variables |
+| `error` | VARCHAR | Error message if failed |
+| `extract` | VARCHAR | Result of `extract` specs |
+| `response_time_ms` | BIGINT | Request duration |
+| `depth` | INTEGER | Crawl depth from seed |
 
 ## Examples
 
 ### Basic Crawl
 
 ```sql
--- Crawl a website
-CRAWL (SELECT 'https://example.com/')
-INTO pages
-WITH (max_crawl_pages 100);
+CREATE TABLE pages AS
+SELECT * FROM crawl('https://example.com/', timeout := 30, max_results := 100);
 
--- Query the results
-SELECT url, status_code, jsonld FROM pages WHERE status_code = 200;
+SELECT url, status, html.schema FROM pages WHERE status = 200;
 ```
 
 ### Crawl with Link Following
 
 ```sql
-CRAWL (SELECT 'https://news.example.com/')
-INTO articles
-WHERE url LIKE '%/article/%'
-WITH (follow_links true, max_crawl_depth 2, max_crawl_pages 500);
+SELECT * FROM crawl(
+    'https://news.example.com/',
+    follow := 'a[href]',
+    max_depth := 2,
+    max_results := 500,
+    timeout := 30
+);
 ```
 
 ### URL Filtering
 
 ```sql
-CRAWL (SELECT 'https://shop.example.com/sitemap.xml')
-INTO products
-WHERE url LIKE '%/product/%'
-WITH (max_crawl_pages 1000);
+SELECT s.url
+FROM sitemap('https://shop.example.com/sitemap.xml',
+             filter := '%/product/%', timeout := 30) s;
 ```
 
 ## Error Handling
@@ -543,13 +568,10 @@ Errors are classified for easy filtering:
 | `content_type_rejected` | Content-Type filtered |
 
 ```sql
--- Retry failed URLs
-CRAWL (
-    SELECT url FROM my_crawl
-    WHERE error_type = 'network_timeout'
-)
-INTO my_crawl_retry
-WITH (user_agent 'MyBot/1.0', timeout_seconds 60);
+-- Retry failed URLs (timeout := seconds)
+SELECT c.*
+FROM my_crawl t, LATERAL crawl_url(t.url, timeout := 60, user_agent := 'MyBot/1.0') c
+WHERE t.error = 'network_timeout';
 ```
 
 ## Performance

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -35,7 +35,7 @@
 
 - Default thread count: DuckDB's `threads` setting (via `current_setting('threads')`)
 - Capped at 32 threads maximum, minimum 1
-- Configurable via `threads` parameter in WITH clause
+- Configurable via `crawl(..., workers := n)` (not a `CRAWL … WITH` clause on community)
 - Per-domain rate limiting preserved across all threads
 - Global connection limit via `max_total_connections`
 - Per-domain parallelism limit via `max_parallel_per_domain`
@@ -64,8 +64,8 @@
 - Cache discovered URLs with metadata (lastmod, changefreq)
 
 ### Link-Following (Optional)
-- BFS crawl from start URL when enabled (`follow_links = true`)
-- Respect `max_crawl_depth` and `max_crawl_pages`
+- BFS crawl from start URL when `follow` is a CSS selector
+- Respect `max_depth` and `max_results`
 - Honor `rel="nofollow"` when `respect_nofollow = true`
 - Follow canonical URLs when `follow_canonical = true`
 
@@ -116,16 +116,35 @@ Crawler reads these settings from DuckDB configuration at crawl start:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `threads` | Number of worker threads | varies |
-| `http_timeout` | Request timeout in seconds | 30 |
-| `http_keep_alive` | Enable connection keep-alive | true |
+| `crawler_user_agent` | User-Agent header | `DuckDB-Crawler/1.0` |
+| `crawler_default_delay` | Default crawl delay **in seconds** | 1.0 |
+| `crawler_timeout_ms` | Default HTTP timeout **in milliseconds** | 30000 |
+| `crawler_respect_robots` | Honor robots.txt | true |
+| `crawler_max_response_bytes` | Max response body size | 10485760 |
 | `http_proxy` | HTTP proxy host | empty |
 | `http_proxy_username` | Proxy authentication username | empty |
 | `http_proxy_password` | Proxy authentication password | empty |
 
-Example:
+Per-call override: TVF named param `timeout` is **seconds** (`timeout := 30` → 30000 ms). Do not pass `crawler_timeout_ms` as a named argument.
+
+`CRAWL (SELECT …) INTO` parser-errors on stock community. Use table functions:
+
 ```sql
-SET http_timeout = 60;
+SET crawler_timeout_ms = 60000;  -- milliseconds, session default
 SET http_proxy = 'http://proxy.example.com:8080';
-CRAWL (SELECT 'https://example.com/') INTO pages;
+SELECT * FROM crawl('https://example.com/', timeout := 60);  -- seconds, this call
 ```
+
+## Named parameters (community `LOAD crawler`)
+
+### crawl()
+
+`timeout`, `max_results`, `max_depth`, `workers`, `delay`, `respect_robots`, `cache`, `cache_ttl`, `user_agent`, `extract`, `follow`, `batch_size`, `state_table`
+
+### crawl_url()
+
+`timeout`, `max_results`, `cache`, `cache_ttl`, `user_agent`, `extract`
+
+### sitemap()
+
+`timeout`, `recursive`, `max_depth`, `discover`, `filter`, `user_agent`


### PR DESCRIPTION
Stock community `LOAD crawler` registers `crawl()` / `crawl_url()` / `sitemap()` named parameters. `CRAWL (SELECT …) INTO` is a parser error.

- Quick start is one-URL `crawl(..., timeout := 30)` (`timeout` is **seconds**; `SET crawler_timeout_ms` is **milliseconds**).
- Named-param tables for the three TVFs in README, EXAMPLES, REQUIREMENTS.
- `CRAWL` statement marked MERGE-only (`CRAWLING MERGE INTO` in `src/crawl_parser.cpp`); parser is not registered on community.

Docs only. No timeout wiring.