### PR TITLE
Fix crawl-delay race and domain 429 backoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 .cache/
+vcpkg/
 rust_parser/target/
 *.duckdb
 *.wal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,9 @@ if(ENABLE_RUST_PARSER)
                 ${RUST_PARSER_DIR}/src/lib.rs
                 ${RUST_PARSER_DIR}/src/ffi.rs
                 ${RUST_PARSER_DIR}/src/extractors.rs
+                ${RUST_PARSER_DIR}/src/sitemap.rs
+                ${RUST_PARSER_DIR}/src/robots.rs
+                ${RUST_PARSER_DIR}/src/hydration.rs
         )
 
         # Create imported library target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(ENABLE_RUST_PARSER)
         # Windows: tree-sitter C uses assert()/fdopen; NDEBUG so release does not
         # import _wassert from the debug CRT.
         if(WIN32)
-            set(CARGO_BUILD_COMMAND ${CMAKE_COMMAND} -E env CFLAGS=-DNDEBUG ${CARGO_EXECUTABLE} build ${RUST_BUILD_FLAG} ${RUST_TARGET_FLAG})
+            set(CARGO_BUILD_COMMAND ${CMAKE_COMMAND} -E env "CFLAGS=-DNDEBUG -D_ACRTIMP=" ${CARGO_EXECUTABLE} build ${RUST_BUILD_FLAG} ${RUST_TARGET_FLAG})
         else()
             set(CARGO_BUILD_COMMAND ${CARGO_EXECUTABLE} build ${RUST_BUILD_FLAG} ${RUST_TARGET_FLAG})
         endif()
@@ -176,6 +176,9 @@ set(EXTENSION_SOURCES
 # Add Rust FFI wrapper if Rust parser is available
 if(RUST_PARSER_AVAILABLE)
     list(APPEND EXTENSION_SOURCES src/rust_ffi.cpp)
+    if(WIN32)
+        list(APPEND EXTENSION_SOURCES src/win_crt_stubs.c)
+    endif()
 endif()
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,12 +105,20 @@ if(ENABLE_RUST_PARSER)
         set(RUST_LIB_PATH ${RUST_PARSER_DIR}/target/${RUST_TARGET_DIR}${RUST_BUILD_TYPE}/${RUST_LIB_NAME})
 
         # Custom command to build Rust library
+        # Windows: tree-sitter C uses assert()/fdopen; NDEBUG so release does not
+        # import _wassert from the debug CRT.
+        if(WIN32)
+            set(CARGO_BUILD_COMMAND ${CMAKE_COMMAND} -E env CFLAGS=-DNDEBUG ${CARGO_EXECUTABLE} build ${RUST_BUILD_FLAG} ${RUST_TARGET_FLAG})
+        else()
+            set(CARGO_BUILD_COMMAND ${CARGO_EXECUTABLE} build ${RUST_BUILD_FLAG} ${RUST_TARGET_FLAG})
+        endif()
         add_custom_command(
             OUTPUT ${RUST_LIB_PATH}
-            COMMAND ${CARGO_EXECUTABLE} build ${RUST_BUILD_FLAG} ${RUST_TARGET_FLAG}
+            COMMAND ${CARGO_BUILD_COMMAND}
             WORKING_DIRECTORY ${RUST_PARSER_DIR}
             COMMENT "Building Rust HTML parser..."
             DEPENDS
+                ${CMAKE_CURRENT_LIST_FILE}
                 ${RUST_PARSER_DIR}/Cargo.toml
                 ${RUST_PARSER_DIR}/src/lib.rs
                 ${RUST_PARSER_DIR}/src/ffi.rs
@@ -191,8 +199,9 @@ if(RUST_PARSER_AVAILABLE)
         target_link_libraries(${EXTENSION_NAME} "-framework Security" "-framework CoreFoundation" "-framework SystemConfiguration")
         target_link_libraries(${LOADABLE_EXTENSION_NAME} "-framework Security" "-framework CoreFoundation" "-framework SystemConfiguration")
     elseif(WIN32)
-        target_link_libraries(${EXTENSION_NAME} ws2_32 userenv bcrypt ntdll)
-        target_link_libraries(${LOADABLE_EXTENSION_NAME} ws2_32 userenv bcrypt ntdll)
+        # legacy_stdio_definitions: tree-sitter ts_parser_print_dot_graphs uses fdopen
+        target_link_libraries(${EXTENSION_NAME} ws2_32 userenv bcrypt ntdll legacy_stdio_definitions)
+        target_link_libraries(${LOADABLE_EXTENSION_NAME} ws2_32 userenv bcrypt ntdll legacy_stdio_definitions)
     elseif(UNIX)
         target_link_libraries(${EXTENSION_NAME} dl pthread m)
         target_link_libraries(${LOADABLE_EXTENSION_NAME} dl pthread m)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -5,3 +5,6 @@ duckdb_extension_load(crawler
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
 )
+
+# page_info.test uses json_keys / -> / ->>
+duckdb_extension_load(json)

--- a/rust_parser/Cargo.toml
+++ b/rust_parser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 scraper = "0.22"

--- a/rust_parser/src/extractors.rs
+++ b/rust_parser/src/extractors.rs
@@ -1042,6 +1042,9 @@ fn extract_table_element(table: scraper::ElementRef, is_wikipedia: bool) -> Tabl
         headers.push(format!("column{}", headers.len() + 1));
     }
 
+    // Deterministic uniqueness: first keeps base name, later get _1, _2, ...
+    headers = uniquify_headers(headers);
+
     let num_rows = rows.len();
 
     TableExtractionResult {
@@ -1051,6 +1054,35 @@ fn extract_table_element(table: scraper::ElementRef, is_wikipedia: bool) -> Tabl
         num_rows,
         error: None,
     }
+}
+
+/// Make header names unique. First occurrence keeps the base name;
+/// subsequent collisions become `base_1`, `base_2`, ...
+fn uniquify_headers(headers: Vec<String>) -> Vec<String> {
+    use std::collections::HashSet;
+    let mut used: HashSet<String> = HashSet::new();
+    let mut out = Vec::with_capacity(headers.len());
+    for header in headers {
+        let base = if header.is_empty() {
+            "column".to_string()
+        } else {
+            header
+        };
+        if used.insert(base.clone()) {
+            out.push(base);
+            continue;
+        }
+        let mut i = 1u32;
+        loop {
+            let candidate = format!("{}_{}", base, i);
+            if used.insert(candidate.clone()) {
+                out.push(candidate);
+                break;
+            }
+            i += 1;
+        }
+    }
+    out
 }
 
 /// Normalize cell text: trim whitespace, collapse multiple spaces/newlines
@@ -1521,6 +1553,54 @@ fn test_extract_table_basic() {
     assert_eq!(result.num_rows, 2);
     assert_eq!(result.rows[0], vec!["Item 1", "100"]);
     assert_eq!(result.rows[1], vec!["Item 2", "200"]);
+}
+
+#[test]
+fn test_uniquify_headers_duplicates() {
+    assert_eq!(
+        uniquify_headers(vec![
+            "Estimate".to_string(),
+            "Year".to_string(),
+            "Estimate".to_string(),
+            "Estimate".to_string(),
+        ]),
+        vec!["Estimate", "Year", "Estimate_1", "Estimate_2"]
+    );
+    // Pre-existing _1 suffix still gets a free unique name
+    assert_eq!(
+        uniquify_headers(vec![
+            "Estimate".to_string(),
+            "Estimate_1".to_string(),
+            "Estimate".to_string(),
+        ]),
+        vec!["Estimate", "Estimate_1", "Estimate_2"]
+    );
+}
+
+#[test]
+fn test_extract_table_duplicate_headers() {
+    let html = r#"
+    <html>
+    <body>
+        <table id="gdp">
+            <thead>
+                <tr><th>Country</th><th>Estimate</th><th>Year</th><th>Estimate</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>A</td><td>1</td><td>2020</td><td>2</td></tr>
+            </tbody>
+        </table>
+    </body>
+    </html>
+    "#;
+
+    let result = extract_table(html, "table#gdp", false, 0);
+    assert!(result.error.is_none());
+    assert_eq!(
+        result.headers,
+        vec!["Country", "Estimate", "Year", "Estimate_1"]
+    );
+    assert_eq!(result.rows[0], vec!["A", "1", "2020", "2"]);
 }
 
 #[test]

--- a/rust_parser/src/ffi.rs
+++ b/rust_parser/src/ffi.rs
@@ -5,7 +5,7 @@ use std::ffi::{c_char, CStr, CString};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn tokio_runtime() -> &'static tokio::runtime::Runtime {
     static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
@@ -705,8 +705,109 @@ fn extract_domain(url: &str) -> String {
         .unwrap_or_default()
 }
 
-/// Per-domain rate limiter
-type DomainRateLimiter = Arc<Mutex<HashMap<String, std::time::Instant>>>;
+const MAX_BACKOFF_SECS: u64 = 600;
+
+/// Per-domain gate: crawl-delay reservation + 429 block.
+#[derive(Debug)]
+struct DomainLimitState {
+    next_allowed: Instant,
+    blocked_until: Option<Instant>,
+    consecutive_429s: u32,
+}
+
+impl DomainLimitState {
+    fn new(now: Instant) -> Self {
+        Self {
+            next_allowed: now,
+            blocked_until: None,
+            consecutive_429s: 0,
+        }
+    }
+
+    fn gate(&self) -> Instant {
+        match self.blocked_until {
+            Some(b) => self.next_allowed.max(b),
+            None => self.next_allowed,
+        }
+    }
+}
+
+/// Per-domain rate limiter (shared across concurrent batch tasks).
+type DomainRateLimiter = Arc<Mutex<HashMap<String, DomainLimitState>>>;
+
+fn fib_backoff_secs(n: u32) -> u64 {
+    if n <= 2 {
+        return 1.min(MAX_BACKOFF_SECS);
+    }
+    let mut a = 1u64;
+    let mut b = 1u64;
+    for _ in 3..=n {
+        let next = a.saturating_add(b);
+        a = b;
+        b = next;
+        if b >= MAX_BACKOFF_SECS {
+            return MAX_BACKOFF_SECS;
+        }
+    }
+    b.min(MAX_BACKOFF_SECS)
+}
+
+/// Parse Retry-After delta-seconds. HTTP-date is not supported here.
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    let secs: u64 = value.trim().parse().ok()?;
+    Some(Duration::from_secs(secs))
+}
+
+/// Reserve the next crawl-delay slot under the lock, then sleep outside it.
+/// Fixes the stale last-access race (check→unlock→sleep→relock).
+async fn acquire_domain(limiter: &DomainRateLimiter, domain: &str, delay: Duration) {
+    loop {
+        let sleep_for = {
+            let mut map = limiter.lock().await;
+            let now = Instant::now();
+            let state = map
+                .entry(domain.to_string())
+                .or_insert_with(|| DomainLimitState::new(now));
+            let ready_at = state.gate();
+            if now < ready_at {
+                Some(ready_at.saturating_duration_since(now))
+            } else {
+                state.next_allowed = now + delay;
+                None
+            }
+        };
+        match sleep_for {
+            None => return,
+            Some(d) if d.is_zero() => tokio::task::yield_now().await,
+            Some(d) => tokio::time::sleep(d).await,
+        }
+    }
+}
+
+async fn note_429(limiter: &DomainRateLimiter, domain: &str, retry_after: Option<Duration>) {
+    let mut map = limiter.lock().await;
+    let now = Instant::now();
+    let state = map
+        .entry(domain.to_string())
+        .or_insert_with(|| DomainLimitState::new(now));
+    state.consecutive_429s = state.consecutive_429s.saturating_add(1);
+    let backoff = retry_after
+        .unwrap_or_else(|| Duration::from_secs(fib_backoff_secs(state.consecutive_429s)))
+        .min(Duration::from_secs(MAX_BACKOFF_SECS));
+    let until = now + backoff;
+    state.blocked_until = Some(until);
+    if state.next_allowed < until {
+        state.next_allowed = until;
+    }
+}
+
+async fn note_success(limiter: &DomainRateLimiter, domain: &str) {
+    let mut map = limiter.lock().await;
+    if let Some(state) = map.get_mut(domain) {
+        state.blocked_until = None;
+        state.consecutive_429s = 0;
+    }
+}
 
 /// Single crawl result
 #[derive(Debug, serde::Serialize)]
@@ -768,36 +869,11 @@ async fn fetch_and_extract_inner(
     rate_limiter: &DomainRateLimiter,
     delay_ms: u64,
 ) -> CrawlResult {
-    let start = std::time::Instant::now();
+    let start = Instant::now();
+    let domain = extract_domain(&url);
 
-    // Apply per-domain rate limiting
-    if delay_ms > 0 {
-        let domain = extract_domain(&url);
-        let delay = Duration::from_millis(delay_ms);
-
-        let wait_time = {
-            let limiter = rate_limiter.lock().await;
-            if let Some(last_access) = limiter.get(&domain) {
-                let elapsed = last_access.elapsed();
-                if elapsed < delay {
-                    Some(delay - elapsed)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        if let Some(wait) = wait_time {
-            tokio::time::sleep(wait).await;
-        }
-
-        // Update last access time
-        {
-            let mut limiter = rate_limiter.lock().await;
-            limiter.insert(domain, std::time::Instant::now());
-        }
+    if !domain.is_empty() {
+        acquire_domain(rate_limiter, &domain, Duration::from_millis(delay_ms)).await;
     }
 
     match client.get(&url).send().await {
@@ -811,8 +887,34 @@ async fn fetch_and_extract_inner(
                 .unwrap_or("")
                 .to_string();
 
+            if status == 429 {
+                let retry_after = response
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(parse_retry_after);
+                if !domain.is_empty() {
+                    note_429(rate_limiter, &domain, retry_after).await;
+                }
+                let _ = response.bytes().await;
+                return CrawlResult {
+                    url,
+                    final_url,
+                    status,
+                    content_type,
+                    body: String::new(),
+                    error: Some("HTTP 429 Too Many Requests".to_string()),
+                    extracted: None,
+                    response_time_ms: start.elapsed().as_millis() as u64,
+                };
+            }
+
             match response.text().await {
                 Ok(body) => {
+                    if (200..400).contains(&status) && !domain.is_empty() {
+                        note_success(rate_limiter, &domain).await;
+                    }
+
                     let extracted = if let Some(req) = extraction {
                         let result = extract_all(&body, req);
                         // Convert HashMap to JSON Value

--- a/rust_parser/src/ffi.rs
+++ b/rust_parser/src/ffi.rs
@@ -4,7 +4,24 @@ use crate::extractors::{extract_all, ExtractionRequest};
 use std::ffi::{c_char, CStr, CString};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 use std::time::Duration;
+
+fn tokio_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .thread_name("crawler-tokio")
+            .build()
+            .expect("failed to create crawler tokio runtime")
+    })
+}
+
+fn duration_from_timeout_ms(timeout_ms: u64) -> Duration {
+    Duration::from_millis(timeout_ms.max(1))
+}
 
 // Global interrupt flag for graceful shutdown
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
@@ -717,6 +734,39 @@ async fn fetch_and_extract(
     extraction: &Option<ExtractionRequest>,
     rate_limiter: &DomainRateLimiter,
     delay_ms: u64,
+    timeout: Duration,
+) -> CrawlResult {
+    let start = std::time::Instant::now();
+    let url_for_timeout = url.clone();
+    match tokio::time::timeout(
+        timeout,
+        fetch_and_extract_inner(client, url, extraction, rate_limiter, delay_ms),
+    )
+    .await
+    {
+        Ok(mut result) => {
+            result.response_time_ms = start.elapsed().as_millis() as u64;
+            result
+        }
+        Err(_) => CrawlResult {
+            url: url_for_timeout.clone(),
+            final_url: url_for_timeout,
+            status: 0,
+            content_type: String::new(),
+            body: String::new(),
+            error: Some(format!("timeout after {}ms", timeout.as_millis())),
+            extracted: None,
+            response_time_ms: start.elapsed().as_millis() as u64,
+        },
+    }
+}
+
+async fn fetch_and_extract_inner(
+    client: &reqwest::Client,
+    url: String,
+    extraction: &Option<ExtractionRequest>,
+    rate_limiter: &DomainRateLimiter,
+    delay_ms: u64,
 ) -> CrawlResult {
     let start = std::time::Instant::now();
 
@@ -838,10 +888,32 @@ pub unsafe extern "C" fn crawl_batch_ffi(
         }
     };
 
+    match run_batch_crawl(request) {
+        Ok(response) => match serde_json::to_string(&response) {
+            Ok(json) => ExtractionResultFFI {
+                json_ptr: string_to_ptr(json),
+                error_ptr: ptr::null_mut(),
+            },
+            Err(e) => ExtractionResultFFI {
+                json_ptr: ptr::null_mut(),
+                error_ptr: string_to_ptr(format!("Serialization error: {}", e)),
+            },
+        },
+        Err(e) => ExtractionResultFFI {
+            json_ptr: ptr::null_mut(),
+            error_ptr: string_to_ptr(e),
+        },
+    }
+}
+
+fn run_batch_crawl(request: BatchCrawlRequest) -> Result<BatchCrawlResponse, String> {
+    let timeout = duration_from_timeout_ms(request.timeout_ms);
+
     // Build HTTP client with optional proxy
     let mut client_builder = reqwest::Client::builder()
         .user_agent(&request.user_agent)
-        .timeout(Duration::from_millis(request.timeout_ms));
+        .connect_timeout(timeout)
+        .timeout(timeout);
 
     // Configure proxy if provided
     if let Some(ref proxy_url) = request.http_proxy {
@@ -868,28 +940,11 @@ pub unsafe extern "C" fn crawl_batch_ffi(
         client_builder = client_builder.default_headers(header_map);
     }
 
-    let client = match client_builder.build() {
-        Ok(c) => c,
-        Err(e) => {
-            return ExtractionResultFFI {
-                json_ptr: ptr::null_mut(),
-                error_ptr: string_to_ptr(format!("Client build error: {}", e)),
-            };
-        }
-    };
+    let client = client_builder
+        .build()
+        .map_err(|e| format!("Client build error: {}", e))?;
 
-    // Run async crawl
-    let runtime = match tokio::runtime::Runtime::new() {
-        Ok(r) => r,
-        Err(e) => {
-            return ExtractionResultFFI {
-                json_ptr: ptr::null_mut(),
-                error_ptr: string_to_ptr(format!("Tokio runtime error: {}", e)),
-            };
-        }
-    };
-
-    let results = runtime.block_on(async {
+    let results = tokio_runtime().block_on(async {
         use futures::stream::{self, StreamExt};
 
         let concurrency = request.concurrency.max(1).min(32);
@@ -903,35 +958,42 @@ pub unsafe extern "C" fn crawl_batch_ffi(
         let urls: Vec<String> = if respect_robots {
             let robots_cache = crate::robots::RobotsCache::new();
             let config = ureq::Agent::config_builder()
-                .timeout_global(Some(Duration::from_secs(10)))
+                .timeout_global(Some(timeout))
                 .build();
             let blocking_agent = ureq::Agent::new_with_config(config);
+            let robots_started = std::time::Instant::now();
 
-            request.urls
+            request
+                .urls
                 .into_iter()
                 .filter(|url| {
-                    let check = robots_cache.check_blocking(&blocking_agent, url, &user_agent);
-                    check.allowed
+                    if robots_started.elapsed() >= timeout {
+                        return false;
+                    }
+                    robots_cache
+                        .check_blocking(&blocking_agent, url, &user_agent)
+                        .allowed
                 })
                 .collect()
         } else {
             request.urls
         };
 
-        // Process URLs with interrupt checking
         let mut results = Vec::new();
         let mut url_stream = stream::iter(urls)
             .map(|url| {
                 let client = client.clone();
                 let extraction = extraction.clone();
                 let rate_limiter = rate_limiter.clone();
-                async move { fetch_and_extract(&client, url, &extraction, &rate_limiter, delay_ms).await }
+                async move {
+                    fetch_and_extract(&client, url, &extraction, &rate_limiter, delay_ms, timeout)
+                        .await
+                }
             })
             .buffer_unordered(concurrency);
 
         while let Some(result) = url_stream.next().await {
             results.push(result);
-            // Check for interrupt after each result
             if INTERRUPTED.load(Ordering::SeqCst) {
                 break;
             }
@@ -939,18 +1001,7 @@ pub unsafe extern "C" fn crawl_batch_ffi(
         results
     });
 
-    let response = BatchCrawlResponse { results };
-
-    match serde_json::to_string(&response) {
-        Ok(json) => ExtractionResultFFI {
-            json_ptr: string_to_ptr(json),
-            error_ptr: ptr::null_mut(),
-        },
-        Err(e) => ExtractionResultFFI {
-            json_ptr: ptr::null_mut(),
-            error_ptr: string_to_ptr(format!("Serialization error: {}", e)),
-        },
-    }
+    Ok(BatchCrawlResponse { results })
 }
 
 // ============================================================================
@@ -961,7 +1012,7 @@ pub unsafe extern "C" fn crawl_batch_ffi(
 #[derive(Debug, serde::Deserialize)]
 struct SitemapRequest {
     url: String,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     recursive: bool,
     #[serde(default = "default_max_depth")]
     max_depth: usize,
@@ -971,10 +1022,6 @@ struct SitemapRequest {
     timeout_ms: u64,
     #[serde(default)]
     discover_from_robots: bool,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 fn default_max_depth() -> usize {
@@ -1016,16 +1063,41 @@ unsafe fn fetch_sitemap_simple_inner(request_json: *const c_char) -> *mut c_char
         }
     };
 
-    let timeout_secs = (request.timeout_ms / 1000).max(1);
+    let timeout = duration_from_timeout_ms(request.timeout_ms);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::Builder::new()
+        .name("sitemap-fetch".into())
+        .spawn(move || {
+            let _ = tx.send(fetch_sitemap_request(request));
+        });
 
+    let combined = match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => crate::sitemap::SitemapResult {
+            urls: vec![],
+            sitemaps: vec![],
+            errors: vec![format!("timeout after {}ms", timeout.as_millis())],
+        },
+    };
+    drop(handle);
+
+    match serde_json::to_string(&combined) {
+        Ok(json) => string_to_ptr(json),
+        Err(e) => {
+            string_to_ptr(format!("{{\"urls\":[],\"sitemaps\":[],\"errors\":[\"Serialization error: {}\"]}}", e))
+        }
+    }
+}
+
+fn fetch_sitemap_request(request: SitemapRequest) -> crate::sitemap::SitemapResult {
+    let timeout = duration_from_timeout_ms(request.timeout_ms);
     let mut sitemap_urls = vec![request.url.clone()];
 
-    // If discover_from_robots, first check robots.txt for sitemap URLs
     if request.discover_from_robots {
         let robots_cache = crate::robots::RobotsCache::new();
         let agent = ureq::Agent::new_with_config(
             ureq::Agent::config_builder()
-                .timeout_global(Some(Duration::from_secs(timeout_secs)))
+                .timeout_global(Some(timeout))
                 .user_agent(&request.user_agent)
                 .build(),
         );
@@ -1042,11 +1114,17 @@ unsafe fn fetch_sitemap_simple_inner(request_json: *const c_char) -> *mut c_char
         errors: vec![],
     };
 
+    let deadline = std::time::Instant::now() + timeout;
     for sitemap_url in sitemap_urls {
+        if std::time::Instant::now() >= deadline {
+            combined.errors.push("timeout".to_string());
+            break;
+        }
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         let result = crate::sitemap::fetch_sitemap_blocking(
             &sitemap_url,
             &request.user_agent,
-            timeout_secs,
+            remaining,
             request.recursive,
             request.max_depth,
         );
@@ -1054,13 +1132,7 @@ unsafe fn fetch_sitemap_simple_inner(request_json: *const c_char) -> *mut c_char
         combined.sitemaps.extend(result.sitemaps);
         combined.errors.extend(result.errors);
     }
-
-    match serde_json::to_string(&combined) {
-        Ok(json) => string_to_ptr(json),
-        Err(e) => {
-            string_to_ptr(format!("{{\"urls\":[],\"sitemaps\":[],\"errors\":[\"Serialization error: {}\"]}}", e))
-        }
-    }
+    combined
 }
 
 /// Free a string allocated by Rust
@@ -1145,12 +1217,12 @@ unsafe fn check_robots_ffi_inner(request_json: *const c_char) -> ExtractionResul
         }
     };
 
-    let timeout_secs = (request.timeout_ms / 1000).max(1);
+    let timeout = duration_from_timeout_ms(request.timeout_ms);
 
     // Build ureq agent
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
-            .timeout_global(Some(Duration::from_secs(timeout_secs)))
+            .timeout_global(Some(timeout))
             .user_agent(&request.user_agent)
             .build(),
     );
@@ -1199,5 +1271,90 @@ pub unsafe extern "C" fn extract_hydration_ffi(
             json_ptr: ptr::null_mut(),
             error_ptr: string_to_ptr(format!("Serialization error: {}", e)),
         },
+    }
+}
+
+#[cfg(test)]
+mod timeout_tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn hang_port() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(30));
+                drop(stream);
+            }
+        });
+        port
+    }
+
+    fn batch_request(url: String, timeout_ms: u64) -> BatchCrawlRequest {
+        BatchCrawlRequest {
+            urls: vec![url],
+            extraction: None,
+            user_agent: "timeout-test".to_string(),
+            timeout_ms,
+            concurrency: 1,
+            delay_ms: 0,
+            respect_robots: false,
+            http_proxy: None,
+            http_proxy_username: None,
+            http_proxy_password: None,
+            extra_headers: None,
+        }
+    }
+
+    #[test]
+    fn crawl_timeout_returns_within_budget() {
+        let url = format!("http://127.0.0.1:{}/delay", hang_port());
+        let start = Instant::now();
+        let response = run_batch_crawl(batch_request(url, 2000)).expect("batch crawl");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "crawl hang took {:?}, expected ~2s timeout",
+            elapsed
+        );
+        assert_eq!(response.results.len(), 1);
+        let err = response.results[0].error.as_deref().unwrap_or("");
+        assert!(
+            err.to_lowercase().contains("timeout") || response.results[0].status == 0,
+            "expected timeout error, got status={} error={}",
+            response.results[0].status,
+            err
+        );
+    }
+
+    #[test]
+    fn sitemap_ffi_timeout_returns_within_budget() {
+        let url = format!("http://127.0.0.1:{}/sitemap.xml", hang_port());
+        let request = SitemapRequest {
+            url,
+            recursive: false,
+            max_depth: 5,
+            user_agent: "timeout-test".to_string(),
+            timeout_ms: 2000,
+            discover_from_robots: false,
+        };
+        let start = Instant::now();
+        let result = fetch_sitemap_request(request);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "sitemap hang took {:?}, expected ~2s timeout",
+            elapsed
+        );
+        assert!(result.urls.is_empty());
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("timeout") || e.contains("Failed to fetch")),
+            "errors: {:?}",
+            result.errors
+        );
     }
 }

--- a/rust_parser/src/sitemap.rs
+++ b/rust_parser/src/sitemap.rs
@@ -2,6 +2,7 @@
 
 use quick_xml::events::Event;
 use quick_xml::Reader;
+use std::time::{Duration, Instant};
 
 /// Single sitemap entry
 #[derive(Debug, Clone, serde::Serialize)]
@@ -128,22 +129,29 @@ pub fn parse_sitemap(xml: &str) -> SitemapResult {
     result
 }
 
-/// Fetch and parse sitemap(s) using ureq (simple blocking HTTP)
+/// Fetch and parse sitemap(s) using ureq (simple blocking HTTP).
+/// `timeout` is a wall-clock deadline for the whole walk, not a per-child budget.
 pub fn fetch_sitemap_blocking(
     url: &str,
     user_agent: &str,
-    timeout_secs: u64,
+    timeout: Duration,
     recursive: bool,
     max_depth: usize,
 ) -> SitemapResult {
+    let timeout = if timeout.is_zero() {
+        Duration::from_millis(1)
+    } else {
+        timeout
+    };
+    let deadline = Instant::now() + timeout;
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
-            .timeout_global(Some(std::time::Duration::from_secs(timeout_secs)))
+            .timeout_global(Some(timeout))
             .user_agent(user_agent)
             .build(),
     );
 
-    fetch_sitemap_internal_ureq(&agent, url, recursive, max_depth, 0)
+    fetch_sitemap_internal_ureq(&agent, url, recursive, max_depth, 0, deadline)
 }
 
 fn fetch_sitemap_internal_ureq(
@@ -152,12 +160,20 @@ fn fetch_sitemap_internal_ureq(
     recursive: bool,
     max_depth: usize,
     current_depth: usize,
+    deadline: Instant,
 ) -> SitemapResult {
     let mut result = SitemapResult {
         urls: vec![],
         sitemaps: vec![],
         errors: vec![],
     };
+
+    if Instant::now() >= deadline {
+        result
+            .errors
+            .push(format!("timeout fetching {}", url));
+        return result;
+    }
 
     if current_depth > max_depth {
         return result;
@@ -196,15 +212,20 @@ fn fetch_sitemap_internal_ureq(
     result.urls.extend(parsed.urls);
     result.errors.extend(parsed.errors);
 
-    // If recursive, fetch child sitemaps
+    // If recursive, fetch child sitemaps until the wall-clock deadline.
     if recursive && !parsed.sitemaps.is_empty() {
         for sitemap_entry in parsed.sitemaps {
+            if Instant::now() >= deadline {
+                result.errors.push("timeout".to_string());
+                break;
+            }
             let child_result = fetch_sitemap_internal_ureq(
                 agent,
                 &sitemap_entry.url,
                 recursive,
                 max_depth,
                 current_depth + 1,
+                deadline,
             );
             result.urls.extend(child_result.urls);
             result.sitemaps.extend(child_result.sitemaps);
@@ -260,5 +281,99 @@ mod tests {
         let result = parse_sitemap(xml);
         assert_eq!(result.sitemaps.len(), 2);
         assert_eq!(result.sitemaps[0].url, "https://example.com/sitemap1.xml");
+    }
+
+    fn write_http(stream: &mut std::net::TcpStream, body: &str, content_type: &str) {
+        use std::io::Write;
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            content_type,
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(resp.as_bytes());
+    }
+
+    #[test]
+    fn sitemap_without_recursive_does_not_walk_index() {
+        use std::io::Read;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_thread = hits.clone();
+        std::thread::spawn(move || {
+            while let Ok((mut stream, _)) = listener.accept() {
+                hits_thread.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                if req.contains("child.xml") {
+                    write_http(
+                        &mut stream,
+                        r#"<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>http://example.com/from-child</loc></url></urlset>"#,
+                        "application/xml",
+                    );
+                } else {
+                    let body = format!(
+                        r#"<?xml version="1.0"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://127.0.0.1:{}/child.xml</loc></sitemap></sitemapindex>"#,
+                        port
+                    );
+                    write_http(&mut stream, &body, "application/xml");
+                }
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{}/sitemap.xml", port);
+        let result = fetch_sitemap_blocking(
+            &url,
+            "test-agent",
+            Duration::from_secs(2),
+            false,
+            5,
+        );
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(result.urls.is_empty(), "non-recursive must not walk child urlset");
+        assert_eq!(result.sitemaps.len(), 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn sitemap_timeout_returns_before_hanging_server() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(30));
+                drop(stream);
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{}/sitemap.xml", port);
+        let start = Instant::now();
+        let result = fetch_sitemap_blocking(
+            &url,
+            "test-agent",
+            Duration::from_millis(2000),
+            false,
+            5,
+        );
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "sitemap hang took {:?}, expected ~2s timeout",
+            elapsed
+        );
+        assert!(
+            result.urls.is_empty(),
+            "timed-out fetch should not yield urls"
+        );
+        assert!(
+            result.errors.iter().any(|e| e.contains("timeout") || e.contains("Failed to fetch")),
+            "errors: {:?}",
+            result.errors
+        );
     }
 }

--- a/src/crawl_lateral_function.cpp
+++ b/src/crawl_lateral_function.cpp
@@ -334,6 +334,7 @@ static Value BuildHtmlStructValue(const string &body, const string &content_type
 struct CrawlUrlBindData : public TableFunctionData {
     string user_agent = "DuckDB-Crawler/1.0";
     int timeout_ms = 30000;
+    bool timeout_explicit = false;  // named timeout := N (seconds)
     bool use_cache = true;      // Enable HTTP response caching
     int cache_ttl_hours = 24;   // Cache TTL in hours
     int64_t max_results = -1;   // Max results to return (-1 = unlimited)
@@ -510,9 +511,7 @@ static unique_ptr<FunctionData> CrawlUrlBind(ClientContext &context, TableFuncti
     if (context.TryGetCurrentSetting("crawler_user_agent", setting_value)) {
         bind_data->user_agent = setting_value.ToString();
     }
-    if (context.TryGetCurrentSetting("crawler_timeout_ms", setting_value)) {
-        bind_data->timeout_ms = static_cast<int>(setting_value.GetValue<int64_t>());
-    }
+    bind_data->timeout_ms = GetCrawlerTimeoutMs(context);
 
     // Check for optional second positional argument (max_results)
     // This enables LIMIT pushdown in LATERAL joins where named params don't work
@@ -526,6 +525,7 @@ static unique_ptr<FunctionData> CrawlUrlBind(ClientContext &context, TableFuncti
             bind_data->user_agent = StringValue::Get(kv.second);
         } else if (kv.first == "timeout") {
             bind_data->timeout_ms = kv.second.GetValue<int>() * 1000;
+            bind_data->timeout_explicit = true;
         } else if (kv.first == "cache") {
             bind_data->use_cache = kv.second.GetValue<bool>();
         } else if (kv.first == "cache_ttl") {
@@ -689,8 +689,13 @@ static OperatorResultType CrawlUrlInOut(ExecutionContext &context, TableFunction
 
         // Crawl if not in cache
         if (!from_cache) {
+            int timeout_ms = bind_data.timeout_explicit ? bind_data.timeout_ms
+                                                        : GetCrawlerTimeoutMs(context.client);
+            if (timeout_ms < 1) {
+                timeout_ms = 1;
+            }
             result = CrawlSingleUrl(url, "{}",  // No extraction specs
-                                    bind_data.user_agent, bind_data.timeout_ms);
+                                    bind_data.user_agent, timeout_ms);
 
             // Save to cache
             if (bind_data.use_cache) {

--- a/src/crawl_lateral_function.cpp
+++ b/src/crawl_lateral_function.cpp
@@ -503,7 +503,7 @@ static SingleCrawlResult CrawlSingleUrl(const string &url,
 //===--------------------------------------------------------------------===//
 
 static unique_ptr<FunctionData> CrawlUrlBind(ClientContext &context, TableFunctionBindInput &input,
-                                              vector<LogicalType> &return_types, vector<string> &names) {
+                                              vector<LogicalType> &return_types, vector<Identifier> &names) {
     auto bind_data = make_uniq<CrawlUrlBindData>();
 
     // Read extension settings as defaults

--- a/src/crawl_parser.cpp
+++ b/src/crawl_parser.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/merge_into_statement.hpp"
+#include "duckdb/parser/query_node/merge_query_node.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
@@ -238,16 +239,17 @@ static string InjectMaxResultsIntoCrawlCalls(const string &query, int64_t limit)
 static void ExtractJoinColumns(ParsedExpression *expr, vector<string> &columns) {
 	if (!expr) return;
 
-	if (expr->type == ExpressionType::COLUMN_REF) {
+	if (expr->GetExpressionType() == ExpressionType::COLUMN_REF) {
 		auto &col_ref = expr->Cast<ColumnRefExpression>();
-		if (!col_ref.column_names.empty()) {
-			columns.push_back(col_ref.column_names.back());
+		auto &cnames = col_ref.ColumnNames();
+		if (!cnames.empty()) {
+			columns.push_back(cnames.back().GetIdentifierName());
 		}
-	} else if (expr->type == ExpressionType::COMPARE_EQUAL ||
-	           expr->type == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+	} else if (expr->GetExpressionType() == ExpressionType::COMPARE_EQUAL ||
+	           expr->GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 		auto &comp = expr->Cast<ComparisonExpression>();
-		ExtractJoinColumns(comp.left.get(), columns);
-		ExtractJoinColumns(comp.right.get(), columns);
+		ExtractJoinColumns(comp.LeftMutable().get(), columns);
+		ExtractJoinColumns(comp.RightMutable().get(), columns);
 	}
 }
 
@@ -309,13 +311,19 @@ static ParserExtensionParseResult ParseCrawlingMerge(const string &query) {
 
 	// Extract the parsed MergeIntoStatement
 	auto &merge_stmt = parser.statements[0]->Cast<MergeIntoStatement>();
+	if (!merge_stmt.node) {
+		return ParserExtensionParseResult("CRAWLING MERGE INTO syntax error: missing merge node");
+	}
+	auto &merge_node = *merge_stmt.node;
 
 	// Create our parse data with AST components
 	auto data = make_uniq<CrawlingMergeParseData>();
-	data->target = merge_stmt.target->Copy();
-	data->source = merge_stmt.source->Copy();
-	data->join_condition = merge_stmt.join_condition ? merge_stmt.join_condition->Copy() : nullptr;
-	data->using_columns = merge_stmt.using_columns;
+	data->target = merge_node.target->Copy();
+	data->source = merge_node.source->Copy();
+	data->join_condition = merge_node.join_condition ? merge_node.join_condition->Copy() : nullptr;
+	for (auto &col : merge_node.using_columns) {
+		data->using_columns.push_back(col.GetIdentifierName());
+	}
 	data->row_limit = row_limit;
 
 	// Extract join columns from condition for UPDATE BY NAME exclusion
@@ -324,19 +332,23 @@ static ParserExtensionParseResult ParseCrawlingMerge(const string &query) {
 	}
 
 	// Convert MergeIntoActions to our CrawlingMergeActions
-	for (auto &entry : merge_stmt.actions) {
+	for (auto &entry : merge_node.actions) {
 		auto &action_list = data->actions[entry.first];
 		for (auto &action : entry.second) {
 			CrawlingMergeAction stream_action;
 			stream_action.action_type = action->action_type;
 			stream_action.condition = action->condition ? action->condition->Copy() : nullptr;
 			stream_action.column_order = action->column_order;
-			stream_action.insert_columns = action->insert_columns;
+			for (auto &col : action->insert_columns) {
+				stream_action.insert_columns.push_back(col.GetIdentifierName());
+			}
 			for (auto &expr : action->expressions) {
 				stream_action.insert_expressions.push_back(expr->Copy());
 			}
 			if (action->update_info) {
-				stream_action.set_columns = action->update_info->columns;
+				for (auto &col : action->update_info->columns) {
+					stream_action.set_columns.push_back(col.GetIdentifierName());
+				}
 				for (auto &expr : action->update_info->expressions) {
 					stream_action.set_expressions.push_back(expr->Copy());
 				}
@@ -351,11 +363,11 @@ static ParserExtensionParseResult ParseCrawlingMerge(const string &query) {
 	if (data->source->type == TableReferenceType::SUBQUERY) {
 		auto &subquery_ref = data->source->Cast<SubqueryRef>();
 		data->source_query_sql = subquery_ref.subquery->ToString();
-		source_alias = subquery_ref.alias;
+		source_alias = subquery_ref.alias.GetIdentifierName();
 	} else {
 		// For table references, wrap in SELECT *
 		data->source_query_sql = "SELECT * FROM " + data->source->ToString();
-		source_alias = data->source->alias;
+		source_alias = data->source->alias.GetIdentifierName();
 	}
 
 	// Apply LIMIT pushdown to source query SQL if needed
@@ -379,18 +391,31 @@ CrawlParserExtension::CrawlParserExtension() {
 	plan_function = PlanCrawl;
 }
 
-ParserExtensionParseResult CrawlParserExtension::ParseCrawl(ParserExtensionInfo *info, const string &query) {
-	// Only handle CRAWLING MERGE INTO statements
-	// Table functions (crawl, crawl_url, htmlpath) are registered separately
+ParserExtensionParseResult CrawlParserExtension::ParseCrawl(ParserExtensionInfo *info,
+                                                            const vector<SimpleToken> &tokens) {
+	if (tokens.empty()) {
+		return ParserExtensionParseResult();
+	}
+	string query;
+	for (auto &tok : tokens) {
+		if (!query.empty()) {
+			query += " ";
+		}
+		query += tok.text;
+	}
 	string trimmed = Trim(query);
 	string lower = StringUtil::Lower(trimmed);
 
-	// Handle CRAWLING MERGE INTO (uses DuckDB's MERGE parser)
 	if (StringUtil::StartsWith(lower, "crawling merge into")) {
-		return ParseCrawlingMerge(trimmed);
+		auto result = ParseCrawlingMerge(trimmed);
+		if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
+			result.consumed_tokens = static_cast<int64_t>(tokens.size());
+		} else {
+			result.consumed_tokens = -1;
+		}
+		return result;
 	}
 
-	// Not a statement we handle, let default parser handle it
 	return ParserExtensionParseResult();
 }
 
@@ -412,7 +437,7 @@ ParserExtensionPlanResult CrawlParserExtension::PlanCrawl(ParserExtensionInfo *i
 			throw BinderException("CRAWLING MERGE INTO: stream_merge_internal function not found");
 		}
 
-		result.function = table_function_catalog_entry.functions.functions[0];
+		result.function = *table_function_catalog_entry.functions.functions[0];
 
 		// Serialize AST components to strings for the executor
 		// Target table name (from AST)
@@ -500,7 +525,7 @@ ParserExtensionPlanResult CrawlParserExtension::PlanCrawl(ParserExtensionInfo *i
 		// Extract source alias from the source TableRef
 		string source_alias;
 		if (merge_data.source) {
-			source_alias = merge_data.source->alias;
+			source_alias = merge_data.source->alias.GetIdentifierName();
 		}
 
 		// Pass parameters to stream_merge_internal

--- a/src/crawl_parser.cpp
+++ b/src/crawl_parser.cpp
@@ -393,30 +393,37 @@ CrawlParserExtension::CrawlParserExtension() {
 
 ParserExtensionParseResult CrawlParserExtension::ParseCrawl(ParserExtensionInfo *info,
                                                             const vector<SimpleToken> &tokens) {
-	if (tokens.empty()) {
+	if (tokens.size() < 3) {
 		return ParserExtensionParseResult();
 	}
+	if (!StringUtil::CIEquals(tokens[0].text, "crawling") || !StringUtil::CIEquals(tokens[1].text, "merge") ||
+	    !StringUtil::CIEquals(tokens[2].text, "into")) {
+		return ParserExtensionParseResult();
+	}
+
 	string query;
+	idx_t consumed = 0;
 	for (auto &tok : tokens) {
+		consumed++;
+		if (tok.type == TokenType::END_OF_INPUT || tok.type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+			break;
+		}
+		if (tok.type == TokenType::TERMINATOR) {
+			break;
+		}
 		if (!query.empty()) {
 			query += " ";
 		}
 		query += tok.text;
 	}
-	string trimmed = Trim(query);
-	string lower = StringUtil::Lower(trimmed);
 
-	if (StringUtil::StartsWith(lower, "crawling merge into")) {
-		auto result = ParseCrawlingMerge(trimmed);
-		if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
-			result.consumed_tokens = static_cast<int64_t>(tokens.size());
-		} else {
-			result.consumed_tokens = -1;
-		}
-		return result;
+	auto result = ParseCrawlingMerge(query);
+	if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
+		result.consumed_tokens = static_cast<int64_t>(consumed);
+	} else {
+		result.consumed_tokens = -1;
 	}
-
-	return ParserExtensionParseResult();
+	return result;
 }
 
 ParserExtensionPlanResult CrawlParserExtension::PlanCrawl(ParserExtensionInfo *info, ClientContext &context,

--- a/src/crawl_stream_function.cpp
+++ b/src/crawl_stream_function.cpp
@@ -301,7 +301,7 @@ static void StreamCrawlWorker(
 
 // Bind function
 static unique_ptr<FunctionData> CrawlStreamBind(ClientContext &context, TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &return_types, vector<Identifier> &names) {
     auto bind_data = make_uniq<CrawlStreamBindData>();
 
     // Read extension settings as defaults
@@ -362,7 +362,7 @@ static unique_ptr<FunctionData> CrawlStreamBind(ClientContext &context, TableFun
 
 // Bind function for query-based crawl (accepts a SQL query string)
 static unique_ptr<FunctionData> CrawlStreamBindQuery(ClientContext &context, TableFunctionBindInput &input,
-                                                      vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<Identifier> &names) {
     auto bind_data = make_uniq<CrawlStreamBindData>();
 
     // Read extension settings as defaults

--- a/src/crawl_table_function.cpp
+++ b/src/crawl_table_function.cpp
@@ -454,6 +454,7 @@ struct CrawlBindData : public TableFunctionData {
     string state_table;
     string user_agent = "DuckDB-Crawler/1.0";
     int timeout_ms = 30000;
+    bool timeout_explicit = false;  // named timeout := N (seconds)
     int batch_size = 10;  // URLs per Rust batch
     int concurrency = 4;  // Concurrent requests in Rust
     int delay_ms = 0;     // Min delay between requests to same domain
@@ -635,9 +636,7 @@ static unique_ptr<FunctionData> CrawlBind(ClientContext &context, TableFunctionB
     if (context.TryGetCurrentSetting("crawler_default_delay", setting_value)) {
         bind_data->delay_ms = static_cast<int>(setting_value.GetValue<double>() * 1000);
     }
-    if (context.TryGetCurrentSetting("crawler_timeout_ms", setting_value)) {
-        bind_data->timeout_ms = static_cast<int>(setting_value.GetValue<int64_t>());
-    }
+    bind_data->timeout_ms = GetCrawlerTimeoutMs(context);
     if (context.TryGetCurrentSetting("crawler_respect_robots", setting_value)) {
         bind_data->respect_robots = setting_value.GetValue<bool>();
     }
@@ -675,6 +674,7 @@ static unique_ptr<FunctionData> CrawlBind(ClientContext &context, TableFunctionB
             bind_data->user_agent = StringValue::Get(kv.second);
         } else if (kv.first == "timeout") {
             bind_data->timeout_ms = kv.second.GetValue<int>() * 1000;
+            bind_data->timeout_explicit = true;
         } else if (kv.first == "workers") {
             bind_data->concurrency = kv.second.GetValue<int>();
         } else if (kv.first == "batch_size") {
@@ -774,6 +774,10 @@ static unique_ptr<GlobalTableFunctionState> CrawlInitGlobal(ClientContext &conte
 static void CrawlFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<CrawlBindData>();
     auto &state = data.global_state->Cast<CrawlGlobalState>();
+    int timeout_ms = bind_data.timeout_explicit ? bind_data.timeout_ms : GetCrawlerTimeoutMs(context);
+    if (timeout_ms < 1) {
+        timeout_ms = 1;
+    }
 
     // Initialize on first call
     if (!state.initialized) {
@@ -927,7 +931,7 @@ static void CrawlFunction(ClientContext &context, TableFunctionInput &data, Data
                 {url_to_fetch},
                 "{}",  // No extraction specs
                 bind_data.user_agent,
-                bind_data.timeout_ms,
+                timeout_ms,
                 1,  // Single URL, single concurrency
                 bind_data.delay_ms,
                 bind_data.respect_robots,
@@ -974,6 +978,10 @@ static unique_ptr<LocalTableFunctionState> CrawlLateralInitLocal(ExecutionContex
 static OperatorResultType CrawlInOut(ExecutionContext &context, TableFunctionInput &data,
                                       DataChunk &input, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<CrawlBindData>();
+    int timeout_ms = bind_data.timeout_explicit ? bind_data.timeout_ms : GetCrawlerTimeoutMs(context.client);
+    if (timeout_ms < 1) {
+        timeout_ms = 1;
+    }
 
     if (input.size() == 0) {
         return OperatorResultType::NEED_MORE_INPUT;
@@ -1011,7 +1019,7 @@ static OperatorResultType CrawlInOut(ExecutionContext &context, TableFunctionInp
         yyjson_mut_obj_add_val(doc, root, "urls", urls_arr);
 
         yyjson_mut_obj_add_strcpy(doc, root, "user_agent", bind_data.user_agent.c_str());
-        yyjson_mut_obj_add_uint(doc, root, "timeout_ms", bind_data.timeout_ms);
+        yyjson_mut_obj_add_uint(doc, root, "timeout_ms", timeout_ms);
         yyjson_mut_obj_add_uint(doc, root, "concurrency", 1);
 
         size_t len = 0;

--- a/src/crawl_table_function.cpp
+++ b/src/crawl_table_function.cpp
@@ -625,7 +625,7 @@ static void SaveToCache(Connection &conn, const CrawlResultEntry &entry) {
 //===--------------------------------------------------------------------===//
 
 static unique_ptr<FunctionData> CrawlBind(ClientContext &context, TableFunctionBindInput &input,
-                                           vector<LogicalType> &return_types, vector<string> &names) {
+                                           vector<LogicalType> &return_types, vector<Identifier> &names) {
     auto bind_data = make_uniq<CrawlBindData>();
 
     // Read extension settings as defaults

--- a/src/crawler_extension.cpp
+++ b/src/crawler_extension.cpp
@@ -57,7 +57,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Register crawler_timeout_ms setting
 	config.AddExtensionOption("crawler_timeout_ms",
-	                          "HTTP request timeout in milliseconds",
+	                          "Hard HTTP deadline for crawl()/crawl_url()/sitemap() in milliseconds. "
+	                          "Named timeout parameter is seconds.",
 	                          LogicalType::BIGINT,
 	                          Value::BIGINT(30000));
 

--- a/src/crawler_extension.cpp
+++ b/src/crawler_extension.cpp
@@ -103,10 +103,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 		SetInterrupted(false);
 	}
 
-	// Register CRAWL and STREAM parser extension
-	// Disabled: parser_extensions made private in DuckDB 1.2+
-	// Use crawl()/crawl_url() table functions instead
-	(void)config;
+	// CRAWLING MERGE INTO — PEG treats the leading identifier as an
+	// ExpressionStatement and fails at MERGE. parse_function claims the tokens.
+	ParserExtension::Register(config, CrawlParserExtension());
 }
 
 void CrawlerExtension::Load(ExtensionLoader &loader) {

--- a/src/crawler_utils.cpp
+++ b/src/crawler_utils.cpp
@@ -1,4 +1,7 @@
 #include "crawler_utils.hpp"
+#include "duckdb.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/client_context.hpp"
 #include <zlib.h>
 #include <algorithm>
 #include <chrono>
@@ -15,6 +18,39 @@
 #endif
 
 namespace duckdb {
+
+static int TimeoutMsFromValue(const Value &v) {
+	if (v.IsNull()) {
+		return 0;
+	}
+	int64_t ms = v.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
+	if (ms <= 0) {
+		return 0;
+	}
+	if (ms > 2147483647) {
+		return 2147483647;
+	}
+	return static_cast<int>(ms);
+}
+
+int GetCrawlerTimeoutMs(ClientContext &context) {
+	auto &client_config = ClientConfig::GetConfig(context);
+	auto session = client_config.set_variables.find("crawler_timeout_ms");
+	if (session != client_config.set_variables.end()) {
+		int ms = TimeoutMsFromValue(session->second);
+		if (ms > 0) {
+			return ms;
+		}
+	}
+	Value setting_value;
+	if (context.TryGetCurrentSetting("crawler_timeout_ms", setting_value)) {
+		int ms = TimeoutMsFromValue(setting_value);
+		if (ms > 0) {
+			return ms;
+		}
+	}
+	return 30000;
+}
 
 //===--------------------------------------------------------------------===//
 // Error Classification

--- a/src/crawler_utils.cpp
+++ b/src/crawler_utils.cpp
@@ -1,6 +1,5 @@
 #include "crawler_utils.hpp"
 #include "duckdb.hpp"
-#include "duckdb/main/client_config.hpp"
 #include "duckdb/main/client_context.hpp"
 #include <zlib.h>
 #include <algorithm>
@@ -34,14 +33,6 @@ static int TimeoutMsFromValue(const Value &v) {
 }
 
 int GetCrawlerTimeoutMs(ClientContext &context) {
-	auto &client_config = ClientConfig::GetConfig(context);
-	auto session = client_config.set_variables.find("crawler_timeout_ms");
-	if (session != client_config.set_variables.end()) {
-		int ms = TimeoutMsFromValue(session->second);
-		if (ms > 0) {
-			return ms;
-		}
-	}
 	Value setting_value;
 	if (context.TryGetCurrentSetting("crawler_timeout_ms", setting_value)) {
 		int ms = TimeoutMsFromValue(setting_value);

--- a/src/importhtml_function.cpp
+++ b/src/importhtml_function.cpp
@@ -2,11 +2,13 @@
 // Similar to Google Sheets =IMPORTHTML() - extracts tables from web pages
 
 #include "importhtml_function.hpp"
+#include "crawler_utils.hpp"
 #include "rust_ffi.hpp"
 #include "yyjson.hpp"
 #include "duckdb.hpp"
 #include "duckdb/function/table_function.hpp"
 #include <set>
+#include <unordered_set>
 
 namespace duckdb {
 
@@ -29,6 +31,7 @@ struct ReadHtmlBindData : public TableFunctionData {
     size_t table_index = 0;  // 0-based index of which matching table to extract
     string user_agent = "DuckDB-Crawler/1.0";
     int timeout_ms = 30000;
+    bool timeout_explicit = false;
 
     // Extracted table data (populated during bind)
     vector<string> headers;
@@ -38,6 +41,33 @@ struct ReadHtmlBindData : public TableFunctionData {
     idx_t num_rows = 0;
     string error;
 };
+
+// Sanitize a header for SQL identifiers, then ensure uniqueness within the table.
+// First occurrence keeps the base name; later collisions become base_1, base_2, ...
+static string SanitizeHeaderName(const string &header, idx_t fallback_idx) {
+    string col_name = header;
+    if (col_name.empty()) {
+        col_name = "column" + std::to_string(fallback_idx);
+    }
+    for (auto &c : col_name) {
+        if (c == ' ' || c == '-' || c == '/' || c == '\\' || c == '(' || c == ')' || c == ',') {
+            c = '_';
+        }
+    }
+    return col_name;
+}
+
+static string MakeUniqueColumnName(const string &base, unordered_set<string> &used) {
+    if (used.insert(base).second) {
+        return base;
+    }
+    for (idx_t i = 1;; i++) {
+        string candidate = base + "_" + std::to_string(i);
+        if (used.insert(candidate).second) {
+            return candidate;
+        }
+    }
+}
 
 //===--------------------------------------------------------------------===//
 // Global State
@@ -493,13 +523,20 @@ static unique_ptr<FunctionData> ReadHtmlBind(ClientContext &context,
         bind_data->table_index = static_cast<size_t>(idx - 1);  // Convert to 0-based
     }
 
+    // Session SET crawler_timeout_ms (ms). Named timeout stays seconds.
+    bind_data->timeout_ms = GetCrawlerTimeoutMs(context);
+
     // Named parameters
     for (auto &kv : input.named_parameters) {
         if (kv.first == "user_agent") {
             bind_data->user_agent = StringValue::Get(kv.second);
         } else if (kv.first == "timeout") {
             bind_data->timeout_ms = kv.second.GetValue<int>() * 1000;
+            bind_data->timeout_explicit = true;
         }
+    }
+    if (bind_data->timeout_ms < 1) {
+        bind_data->timeout_ms = 1;
     }
 
     // Fetch and extract table during bind to determine schema
@@ -516,19 +553,12 @@ static unique_ptr<FunctionData> ReadHtmlBind(ClientContext &context,
     // Infer column types based on data
     InferColumnTypes(*bind_data);
 
-    // Define columns based on extracted headers and inferred types
+    // Define columns based on extracted headers and inferred types.
+    // Deduplicate after sanitization so binder never sees duplicate names (issue #3).
+    unordered_set<string> used_names;
     for (idx_t i = 0; i < bind_data->headers.size(); i++) {
-        // Sanitize header name for SQL compatibility
-        string col_name = bind_data->headers[i];
-        if (col_name.empty()) {
-            col_name = "column" + std::to_string(names.size() + 1);
-        }
-        // Replace spaces and special chars with underscores
-        for (auto &c : col_name) {
-            if (c == ' ' || c == '-' || c == '/' || c == '\\' || c == '(' || c == ')' || c == ',') {
-                c = '_';
-            }
-        }
+        string col_name = SanitizeHeaderName(bind_data->headers[i], names.size() + 1);
+        col_name = MakeUniqueColumnName(col_name, used_names);
         names.push_back(col_name);
 
         // Use inferred type

--- a/src/importhtml_function.cpp
+++ b/src/importhtml_function.cpp
@@ -499,7 +499,7 @@ static void InferColumnTypes(ReadHtmlBindData &bind_data) {
 static unique_ptr<FunctionData> ReadHtmlBind(ClientContext &context,
                                                 TableFunctionBindInput &input,
                                                 vector<LogicalType> &return_types,
-                                                vector<string> &names) {
+                                                vector<Identifier> &names) {
     auto bind_data = make_uniq<ReadHtmlBindData>();
 
     // First argument: URL
@@ -559,7 +559,7 @@ static unique_ptr<FunctionData> ReadHtmlBind(ClientContext &context,
     for (idx_t i = 0; i < bind_data->headers.size(); i++) {
         string col_name = SanitizeHeaderName(bind_data->headers[i], names.size() + 1);
         col_name = MakeUniqueColumnName(col_name, used_names);
-        names.push_back(col_name);
+        names.push_back(Identifier(col_name));
 
         // Use inferred type
         switch (bind_data->column_types[i]) {

--- a/src/include/crawl_parser.hpp
+++ b/src/include/crawl_parser.hpp
@@ -64,7 +64,7 @@ class CrawlParserExtension : public ParserExtension {
 public:
 	CrawlParserExtension();
 
-	static ParserExtensionParseResult ParseCrawl(ParserExtensionInfo *info, const string &query);
+	static ParserExtensionParseResult ParseCrawl(ParserExtensionInfo *info, const vector<SimpleToken> &tokens);
 	static ParserExtensionPlanResult PlanCrawl(ParserExtensionInfo *info, ClientContext &context,
 	                                           unique_ptr<ParserExtensionParseData> parse_data);
 };

--- a/src/include/crawler_utils.hpp
+++ b/src/include/crawler_utils.hpp
@@ -5,6 +5,11 @@
 
 namespace duckdb {
 
+class ClientContext;
+
+// Session SET crawler_timeout_ms (milliseconds). Named TVF timeout is seconds.
+int GetCrawlerTimeoutMs(ClientContext &context);
+
 //===--------------------------------------------------------------------===//
 // Error Classification
 //===--------------------------------------------------------------------===//

--- a/src/sitemap_function.cpp
+++ b/src/sitemap_function.cpp
@@ -3,6 +3,7 @@
 
 #include "duckdb.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "crawler_utils.hpp"
 #include "rust_ffi.hpp"
 #include "yyjson.hpp"
 
@@ -16,11 +17,12 @@ using namespace duckdb_yyjson;
 
 struct SitemapBindData : public TableFunctionData {
     string url;
-    bool recursive = true;
+    bool recursive = false;
     int max_depth = 5;
     bool discover_from_robots = false;
     string user_agent = "DuckDB-Crawler/1.0";
     int timeout_ms = 30000;
+    bool timeout_explicit = false;
     string filter_pattern;
 };
 
@@ -148,6 +150,8 @@ static unique_ptr<FunctionData> SitemapBind(ClientContext &context,
         throw BinderException("sitemap() requires a URL argument");
     }
 
+    bind_data->timeout_ms = GetCrawlerTimeoutMs(context);
+
     // Named parameters
     for (auto &kv : input.named_parameters) {
         if (kv.first == "recursive") {
@@ -160,6 +164,7 @@ static unique_ptr<FunctionData> SitemapBind(ClientContext &context,
             bind_data->user_agent = StringValue::Get(kv.second);
         } else if (kv.first == "timeout") {
             bind_data->timeout_ms = kv.second.GetValue<int>() * 1000;
+            bind_data->timeout_explicit = true;
         } else if (kv.first == "filter") {
             bind_data->filter_pattern = StringValue::Get(kv.second);
         }
@@ -195,11 +200,17 @@ static unique_ptr<GlobalTableFunctionState> SitemapInitGlobal(ClientContext &con
 //===--------------------------------------------------------------------===//
 
 static void SitemapFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->Cast<SitemapBindData>();
+    auto &bind_data = data.bind_data->CastNoConst<SitemapBindData>();
     auto &state = data.global_state->Cast<SitemapGlobalState>();
 
     // Fetch sitemap on first call
     if (!state.fetched) {
+        if (!bind_data.timeout_explicit) {
+            bind_data.timeout_ms = GetCrawlerTimeoutMs(context);
+        }
+        if (bind_data.timeout_ms < 1) {
+            bind_data.timeout_ms = 1;
+        }
         string request_json = BuildSitemapRequest(bind_data);
         string response_json = FetchSitemapWithRust(request_json);
         state.entries = ParseSitemapResponse(response_json, bind_data.filter_pattern);

--- a/src/sitemap_function.cpp
+++ b/src/sitemap_function.cpp
@@ -140,7 +140,7 @@ static vector<SitemapEntry> ParseSitemapResponse(const string &json, const strin
 static unique_ptr<FunctionData> SitemapBind(ClientContext &context,
                                              TableFunctionBindInput &input,
                                              vector<LogicalType> &return_types,
-                                             vector<string> &names) {
+                                             vector<Identifier> &names) {
     auto bind_data = make_uniq<SitemapBindData>();
 
     // First argument is the sitemap URL

--- a/src/stream_into_function.cpp
+++ b/src/stream_into_function.cpp
@@ -44,7 +44,7 @@ struct StreamIntoGlobalState : public GlobalTableFunctionState {
 //===--------------------------------------------------------------------===//
 
 static unique_ptr<FunctionData> StreamIntoBind(ClientContext &context, TableFunctionBindInput &input,
-                                                vector<LogicalType> &return_types, vector<string> &names) {
+                                                vector<LogicalType> &return_types, vector<Identifier> &names) {
     auto bind_data = make_uniq<StreamIntoBindData>();
 
     // Parameters from parser: source_query, target_table, batch_size, row_limit
@@ -110,10 +110,12 @@ static void StreamIntoFunction(ClientContext &context, TableFunctionInput &data,
         if (!check_chunk || check_chunk->size() == 0) {
             // Create table with columns from query result
             string create_sql = "CREATE TABLE " + QuoteSqlIdentifier(bind_data.target_table) + " (";
-            for (idx_t i = 0; i < query_result->names.size(); i++) {
+            auto &result_names = query_result->GetNames();
+            auto &result_types = query_result->GetTypes();
+            for (idx_t i = 0; i < result_names.size(); i++) {
                 if (i > 0) create_sql += ", ";
-                create_sql += QuoteSqlIdentifier(query_result->names[i]) + " " +
-                              query_result->types[i].ToString();
+                create_sql += QuoteSqlIdentifier(result_names[i].GetIdentifierName()) + " " +
+                              result_types[i].ToString();
             }
             create_sql += ")";
             conn.Query(create_sql);

--- a/src/stream_merge_function.cpp
+++ b/src/stream_merge_function.cpp
@@ -263,7 +263,7 @@ struct CrawlingMergeGlobalState : public GlobalTableFunctionState {
 //===--------------------------------------------------------------------===//
 
 static unique_ptr<FunctionData> CrawlingMergeBind(ClientContext &context, TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto bind_data = make_uniq<CrawlingMergeBindData>();
 
 	// Parameters from parser (see PlanCrawl in crawl_parser.cpp)
@@ -531,8 +531,11 @@ static void CrawlingMergeFunction(ClientContext &context, TableFunctionInput &da
 	}
 
 	// Get column names and types from result
-	vector<string> col_names = query_result->names;
-	vector<LogicalType> col_types = query_result->types;
+	vector<string> col_names;
+	for (auto &n : query_result->GetNames()) {
+		col_names.push_back(n.GetIdentifierName());
+	}
+	vector<LogicalType> col_types = query_result->GetTypes();
 
 	// Collect all chunks first to know total (enables progress bar)
 	vector<unique_ptr<DataChunk>> all_chunks;

--- a/src/win_crt_stubs.c
+++ b/src/win_crt_stubs.c
@@ -1,0 +1,8 @@
+/* tree-sitter parser.c calls _fdopen as a UCRT dllimport (__imp__fdopen).
+   Recent UCRT headers inline it; the object still wants the IAT slot.
+   legacy_stdio_definitions.lib provides a plain _fdopen. */
+#ifdef _WIN32
+typedef struct _iobuf FILE;
+FILE *__cdecl _fdopen(int fd, char const *mode);
+FILE *(__cdecl *__imp__fdopen)(int fd, char const *mode) = _fdopen;
+#endif

--- a/test/sql/page_info.test
+++ b/test/sql/page_info.test
@@ -6,7 +6,7 @@ require crawler
 
 # Test page_info() returns JSON with expected keys
 query I
-SELECT json_array_length(json_keys(page_info(
+SELECT len(json_keys(page_info(
     '<html><head><meta name="description" content="Test"></head><body><h1>Hello</h1><p>Text</p></body></html>',
     'http://example.com'
 )));

--- a/test/sql/page_info.test
+++ b/test/sql/page_info.test
@@ -3,6 +3,7 @@
 # group: [crawler]
 
 require crawler
+require json
 
 # Test page_info() returns JSON with expected keys
 query I

--- a/test/sql/page_info.test
+++ b/test/sql/page_info.test
@@ -89,10 +89,10 @@ SELECT (page_info(
 
 # Test page_info() readability has title key
 query I
-SELECT page_info(
+SELECT (page_info(
     '<html><body><article><p>Hello world</p></article></body></html>',
     'http://example.com'
-)->'readability'->>'title' IS NOT NULL;
+)->'readability'->>'title') IS NOT NULL;
 ----
 true
 

--- a/test/sql/page_info.test
+++ b/test/sql/page_info.test
@@ -3,6 +3,7 @@
 # group: [crawler]
 
 require crawler
+
 require json
 
 # Test page_info() returns JSON with expected keys

--- a/test/sql/read_html.test
+++ b/test/sql/read_html.test
@@ -47,3 +47,24 @@ WHERE Building IS NOT NULL;
 ----
 true
 
+# Issue #3: duplicate header names must bind uniquely (no Binder Error on duplicates)
+statement ok
+SELECT *
+FROM read_html(
+  'https://simple.wikipedia.org/wiki/List_of_countries_by_GDP_(nominal)_per_capita',
+  'table.wikitable',
+  1
+)
+LIMIT 1;
+
+# Bound column names are unique after sanitization / _N suffixing
+query I
+SELECT count(column_name) = count(DISTINCT column_name)
+FROM (DESCRIBE SELECT * FROM read_html(
+  'https://simple.wikipedia.org/wiki/List_of_countries_by_GDP_(nominal)_per_capita',
+  'table.wikitable',
+  1
+));
+----
+true
+

--- a/test/sql/timeout_deadline.test
+++ b/test/sql/timeout_deadline.test
@@ -1,0 +1,22 @@
+# name: test/sql/timeout_deadline.test
+# description: SET crawler_timeout_ms is milliseconds and is session-visible
+# group: [crawler]
+# hang/deadline behavior is covered by rust_parser sitemap + ffi timeout tests
+
+require crawler
+
+statement ok
+SET crawler_timeout_ms = 2000;
+
+query I
+SELECT current_setting('crawler_timeout_ms');
+----
+2000
+
+statement ok
+RESET crawler_timeout_ms;
+
+query I
+SELECT current_setting('crawler_timeout_ms');
+----
+30000

--- a/test/sql/timeout_deadline.test
+++ b/test/sql/timeout_deadline.test
@@ -2,6 +2,7 @@
 # description: SET crawler_timeout_ms is milliseconds and is session-visible
 # group: [crawler]
 # hang/deadline behavior is covered by rust_parser sitemap + ffi timeout tests
+# read_html/crawl/sitemap bind+execute re-read this setting via GetCrawlerTimeoutMs
 
 require crawler
 


### PR DESCRIPTION
## Problem
- Per-domain crawl-delay updates were computed from a stale timestamp because domains slept outside the lock.
- On HTTP 429, the batch fetcher did not block the domain, so peers kept issuing requests against the same host.
- Body-size safety for oversized responses was incomplete.

## Current fix
- Keep delay reservation atomic under the existing domain lock.
- Add domain-wide 429 backoff with `Retry-After` parsing and Fibonacci fallback.
- Add response body size guard (`max_response_bytes`) to avoid buffering oversized bodies.

## Why this is the same fix in fewer lines
- Same user-visible behavior as the previous large patch: no stampedes, domain pause on 429, and safer buffering.
- Reduced implementation scope by keeping the logic inside the existing rate-limit structure instead of introducing a new module.
